### PR TITLE
Add runtime configuration for theming and document config usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+backend/node_modules
+backend/dist

--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# MdViewer
+
+MdViewer converts Markdown documents into styled HTML pages and opens them in the default browser. The tool is implemented in TypeScript and can be packaged into a Windows `.exe` for drag-and-drop use.
+
+## Features
+
+- Converts `.md` files to HTML using a lightweight built-in Markdown renderer.
+- Writes the HTML file alongside the source Markdown (or a custom path via `--out`).
+- Launches the generated HTML in the system default browser (Windows `cmd /c start`, macOS `open`, Linux `xdg-open`).
+- Includes opinionated styling with inline CSS for an attractive reading experience.
+- Supports theme customization via a `mdviewer.config.json` file placed beside the executable.
+- Provides automated regression tests with the Node.js test runner.
+- Optional packaging via [`pkg`](https://github.com/vercel/pkg) to produce a standalone Windows executable.
+
+## Getting Started
+
+```bash
+cd backend
+npm install   # requires access to npm registry (typescript download)
+npm run build
+node dist/cli.js path/to/file.md
+```
+
+### CLI Usage
+
+```
+mdviewer <file.md> [--out <file.html>] [--no-open]
+```
+
+- `--out <file.html>`: specify a custom output file.
+- `--no-open`: skip launching the default browser after conversion.
+
+## Configuration
+
+`MdViewer` automatically loads `mdviewer.config.json` located next to the running executable (or the compiled script during development).
+This repository ships with a sample configuration at the project root so the packaged `.exe` immediately uses the custom theme.
+
+### Style Options
+
+| Option                | Type            | Description                                                                 |
+|-----------------------|-----------------|-----------------------------------------------------------------------------|
+| `accentColor`         | string          | Anchor color used for links and interactive highlights.                     |
+| `backgroundColor`     | string          | Background color applied to the `<html>` root element.                      |
+| `backgroundGradient`  | string          | Gradient or color fill for the page background behind the container.       |
+| `baseFontFamily`      | string          | Font stack applied to the entire document.                                  |
+| `codeBlockBackground` | string          | Background color for fenced code blocks.                                    |
+| `codeBlockText`       | string          | Foreground color for code block text.                                       |
+| `containerMaxWidth`   | string or number| Maximum width of the content container (numbers gain a `px` suffix).        |
+| `customCss`           | string          | Extra CSS appended after the base styles for advanced tweaks.               |
+
+Leave any option out to fall back to the built-in defaults.
+
+### Packaging to `.exe`
+
+1. Ensure [`pkg`](https://github.com/vercel/pkg) is installed (`npm install -g pkg`) or available via `npx`.
+2. Build the TypeScript sources:
+   ```bash
+   npm run build
+   ```
+3. Package the executable:
+   ```bash
+   npm run build:exe
+   ```
+   The script copies `mdviewer.config.json` into the `dist/` folder so the executable and config sit side-by-side.
+4. The resulting binary (`dist/MdViewer.exe`) accepts Markdown files as CLI arguments or drag-and-drop payloads.
+
+## Running Tests
+
+```bash
+cd backend
+npm install   # requires registry access
+npm test
+```
+
+The test suite validates the Markdown renderer and the file conversion workflow.
+
+## Notes on Offline Environments
+
+This repository avoids runtime dependencies, but building and testing still require downloading `typescript` (and optionally `pkg`). If registry access is restricted, install those packages manually in an allowed environment or vendor the compiled output.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "mdviewer",
+  "version": "0.1.0",
+  "description": "Command line Markdown to HTML viewer",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "mdviewer": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "npm run build && node --test ../tests/backend",
+    "build:exe": "npm run build && npx pkg dist/cli.js --targets node18-win-x64 --output dist/MdViewer.exe && node -e \"const fs=require('fs');const path=require('path');const cwd=process.cwd();const src=path.resolve(cwd,'../mdviewer.config.json');const dest=path.resolve(cwd,'dist','mdviewer.config.json');fs.copyFileSync(src,dest);\""
+  },
+  "keywords": [
+    "markdown",
+    "html",
+    "converter"
+  ],
+  "author": "MdViewer Contributors",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  },
+  "pkg": {
+    "scripts": "dist/**/*.js",
+    "assets": []
+  }
+}

--- a/backend/src/cli.ts
+++ b/backend/src/cli.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import { existsSync, statSync } from 'fs';
+import path from 'path';
+import { loadConfiguration } from './configuration.js';
+import type { LoadedConfiguration } from './configuration.js';
+import { MarkdownConversionService } from './fileConversionService.js';
+import { openFileInBrowser } from './openInBrowser.js';
+
+interface ParsedArgs {
+  inputPath?: string;
+  outputPath?: string;
+  shouldOpen: boolean;
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArguments(process.argv.slice(2));
+
+  if (!parsed.inputPath) {
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const absoluteInput = path.resolve(parsed.inputPath);
+  if (!existsSync(absoluteInput) || !statSync(absoluteInput).isFile()) {
+    console.error(`Input file not found: ${absoluteInput}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const loadedConfig = loadConfigWithReporting();
+  if (!loadedConfig) {
+    return;
+  }
+
+  const service = new MarkdownConversionService({ config: loadedConfig.config });
+
+  try {
+    const result = await service.convertFile(absoluteInput, parsed.outputPath);
+    console.log(`HTML written to ${result.outputPath}`);
+    if (parsed.shouldOpen) {
+      openFileInBrowser(result.outputPath);
+      console.log('Opening HTML in default browser...');
+    }
+  } catch (error) {
+    console.error(`Failed to convert Markdown: ${(error as Error).message}`);
+    process.exitCode = 3;
+  }
+}
+
+function loadConfigWithReporting(): LoadedConfiguration | undefined {
+  try {
+    const loaded = loadConfiguration();
+    if (loaded.path) {
+      console.log(`Using configuration from ${loaded.path}`);
+    }
+    return loaded;
+  } catch (error) {
+    console.error(`Failed to load configuration: ${(error as Error).message}`);
+    process.exitCode = 5;
+    return undefined;
+  }
+}
+
+function parseArguments(args: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { shouldOpen: true };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--out' || arg === '-o') {
+      const outputCandidate = args[index + 1];
+      if (!outputCandidate) {
+        throw new Error('Missing value for --out option.');
+      }
+      parsed.outputPath = outputCandidate;
+      index += 1;
+    } else if (arg === '--no-open') {
+      parsed.shouldOpen = false;
+    } else if (!parsed.inputPath) {
+      parsed.inputPath = arg;
+    } else {
+      throw new Error(`Unrecognized argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function printUsage(): void {
+  console.log(`Usage: mdviewer <file.md> [--out <file.html>] [--no-open]\n\n` +
+    `Examples:\n  mdviewer README.md\n  mdviewer README.md --out output.html --no-open`);
+}
+
+main().catch(error => {
+  console.error(`Unexpected failure: ${(error as Error).message}`);
+  process.exitCode = 4;
+});

--- a/backend/src/configuration.ts
+++ b/backend/src/configuration.ts
@@ -1,0 +1,160 @@
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+
+export const CONFIG_FILE_NAME = 'mdviewer.config.json';
+
+export interface StyleAdjustOptions {
+  accentColor?: string;
+  backgroundColor?: string;
+  backgroundGradient?: string;
+  baseFontFamily?: string;
+  codeBlockBackground?: string;
+  codeBlockText?: string;
+  containerMaxWidth?: string | number;
+  customCss?: string;
+}
+
+export interface MdViewerConfig {
+  style?: StyleAdjustOptions;
+}
+
+export interface LoadedConfiguration {
+  config: MdViewerConfig;
+  path?: string;
+}
+
+export interface LoadConfigurationOptions {
+  explicitPath?: string;
+  additionalSearchDirectories?: string[];
+}
+
+const defaultConfig: MdViewerConfig = {
+  style: {}
+};
+
+export function loadConfiguration(options: LoadConfigurationOptions = {}): LoadedConfiguration {
+  const searchCandidates = buildSearchCandidates(options);
+
+  for (const candidate of searchCandidates) {
+    if (!candidate) {
+      continue;
+    }
+
+    if (!existsSync(candidate)) {
+      continue;
+    }
+
+    const raw = readFileSync(candidate, 'utf8');
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      throw new Error(`Unable to parse configuration at ${candidate}: ${(error as Error).message}`);
+    }
+
+    const config = mergeConfiguration(parsed);
+    return { config, path: candidate };
+  }
+
+  return { config: cloneConfig(defaultConfig) };
+}
+
+function buildSearchCandidates(options: LoadConfigurationOptions): string[] {
+  const candidates: string[] = [];
+
+  if (options.explicitPath) {
+    candidates.push(path.resolve(options.explicitPath));
+  }
+
+  const executableDir = path.dirname(process.execPath);
+  candidates.push(path.join(executableDir, CONFIG_FILE_NAME));
+
+  if (options.additionalSearchDirectories) {
+    for (const directory of options.additionalSearchDirectories) {
+      candidates.push(path.join(directory, CONFIG_FILE_NAME));
+    }
+  }
+
+  if (process.argv[1]) {
+    const scriptDir = path.dirname(path.resolve(process.argv[1]));
+    candidates.push(path.join(scriptDir, CONFIG_FILE_NAME));
+  }
+
+  candidates.push(path.join(process.cwd(), CONFIG_FILE_NAME));
+
+  return deduplicate(candidates);
+}
+
+function deduplicate(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+function mergeConfiguration(raw: unknown): MdViewerConfig {
+  if (!isRecord(raw)) {
+    throw new Error('Configuration root must be an object.');
+  }
+
+  const style = raw.style !== undefined ? normalizeStyle(raw.style) : undefined;
+  const merged: MdViewerConfig = cloneConfig(defaultConfig);
+
+  if (style) {
+    merged.style = { ...style };
+  }
+
+  return merged;
+}
+
+function normalizeStyle(raw: unknown): StyleAdjustOptions {
+  if (!isRecord(raw)) {
+    throw new Error('The "style" section must be an object.');
+  }
+
+  const style: StyleAdjustOptions = {};
+
+  assignStringIfPresent(style, 'accentColor', raw.accentColor);
+  assignStringIfPresent(style, 'backgroundColor', raw.backgroundColor);
+  assignStringIfPresent(style, 'backgroundGradient', raw.backgroundGradient);
+  assignStringIfPresent(style, 'baseFontFamily', raw.baseFontFamily);
+  assignStringIfPresent(style, 'codeBlockBackground', raw.codeBlockBackground);
+  assignStringIfPresent(style, 'codeBlockText', raw.codeBlockText);
+  assignWidth(style, raw.containerMaxWidth);
+  assignStringIfPresent(style, 'customCss', raw.customCss);
+
+  return style;
+}
+
+function assignStringIfPresent(target: StyleAdjustOptions, key: keyof StyleAdjustOptions, value: unknown): void {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    target[key] = value;
+  }
+}
+
+function assignWidth(target: StyleAdjustOptions, value: unknown): void {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    target.containerMaxWidth = `${value}px`;
+    return;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    target.containerMaxWidth = value;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null;
+}
+
+function cloneConfig(config: MdViewerConfig): MdViewerConfig {
+  return {
+    style: config.style ? { ...config.style } : undefined
+  };
+}

--- a/backend/src/fileConversionService.ts
+++ b/backend/src/fileConversionService.ts
@@ -1,0 +1,59 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { MdViewerConfig } from './configuration.js';
+import { renderMarkdownToHtml } from './markdownRenderer.js';
+
+export interface ConversionSummary {
+  inputPath: string;
+  outputPath: string;
+  html: string;
+}
+
+export interface MarkdownConversionServiceOptions {
+  config?: MdViewerConfig;
+}
+
+export class MarkdownConversionService {
+  private readonly config: MdViewerConfig;
+
+  constructor(options: MarkdownConversionServiceOptions = {}) {
+    this.config = cloneConfig(options.config);
+  }
+
+  async convertFile(inputPath: string, desiredOutput?: string): Promise<ConversionSummary> {
+    const absoluteInput = path.resolve(inputPath);
+    const markdown = await fs.readFile(absoluteInput, 'utf8');
+    const html = renderMarkdownToHtml(markdown, {
+      title: path.basename(absoluteInput, path.extname(absoluteInput)),
+      styleAdjustments: this.config.style
+    });
+
+    const outputPath = desiredOutput
+      ? path.resolve(desiredOutput)
+      : deriveHtmlPath(absoluteInput);
+
+    await fs.writeFile(outputPath, html, 'utf8');
+
+    return {
+      inputPath: absoluteInput,
+      outputPath,
+      html
+    };
+  }
+}
+
+function deriveHtmlPath(inputPath: string): string {
+  const directory = path.dirname(inputPath);
+  const basename = path.basename(inputPath, path.extname(inputPath));
+  return path.join(directory, `${basename}.html`);
+}
+
+function cloneConfig(config?: MdViewerConfig): MdViewerConfig {
+  if (!config) {
+    return { style: undefined };
+  }
+
+  return {
+    style: config.style ? { ...config.style } : undefined
+  };
+}

--- a/backend/src/htmlTemplate.ts
+++ b/backend/src/htmlTemplate.ts
@@ -1,0 +1,173 @@
+import { StyleAdjustOptions } from './configuration.js';
+
+const defaultStyle: ResolvedStyleOptions = {
+  accentColor: '#2563eb',
+  backgroundColor: '#f4f4f5',
+  backgroundGradient: 'radial-gradient(circle at top, #ffffff 0%, #f4f4f5 45%, #e4e4e7 100%)',
+  baseFontFamily: `'Segoe UI', Roboto, Helvetica, Arial, sans-serif`,
+  codeBlockBackground: '#0f172a',
+  codeBlockText: '#e2e8f0',
+  containerMaxWidth: '960px'
+};
+
+export interface HtmlTemplateOptions {
+  title: string;
+  content: string;
+  style?: StyleAdjustOptions;
+}
+
+export function buildHtmlDocument({ title, content, style }: HtmlTemplateOptions): string {
+  const resolvedStyle = resolveStyle(style);
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(title)}</title>
+    <style>${composeStyles(resolvedStyle)}</style>
+  </head>
+  <body>
+    <main class="container">
+      ${content}
+    </main>
+  </body>
+</html>`;
+}
+
+interface ResolvedStyleOptions {
+  accentColor: string;
+  backgroundColor: string;
+  backgroundGradient: string;
+  baseFontFamily: string;
+  codeBlockBackground: string;
+  codeBlockText: string;
+  containerMaxWidth: string;
+  customCss?: string;
+}
+
+function resolveStyle(adjustments?: StyleAdjustOptions): ResolvedStyleOptions {
+  if (!adjustments) {
+    return { ...defaultStyle, customCss: undefined };
+  }
+
+  const customCss = typeof adjustments.customCss === 'string' ? adjustments.customCss.trim() : undefined;
+
+  return {
+    accentColor: adjustments.accentColor ?? defaultStyle.accentColor,
+    backgroundColor: adjustments.backgroundColor ?? defaultStyle.backgroundColor,
+    backgroundGradient: adjustments.backgroundGradient ?? defaultStyle.backgroundGradient,
+    baseFontFamily: adjustments.baseFontFamily ?? defaultStyle.baseFontFamily,
+    codeBlockBackground: adjustments.codeBlockBackground ?? defaultStyle.codeBlockBackground,
+    codeBlockText: adjustments.codeBlockText ?? defaultStyle.codeBlockText,
+    containerMaxWidth: normalizeWidth(adjustments.containerMaxWidth) ?? defaultStyle.containerMaxWidth,
+    customCss: customCss && customCss.length > 0 ? customCss : undefined
+  };
+}
+
+function composeStyles(style: ResolvedStyleOptions): string {
+  const base = `
+    :root {
+      color-scheme: light dark;
+      font-size: 16px;
+      font-family: ${style.baseFontFamily};
+      line-height: 1.6;
+      background-color: ${style.backgroundColor};
+    }
+    body {
+      margin: 0;
+      padding: 2rem 0;
+      display: flex;
+      justify-content: center;
+      background: ${style.backgroundGradient};
+    }
+    .container {
+      max-width: ${style.containerMaxWidth};
+      width: calc(100% - 3rem);
+      background-color: #ffffff;
+      border-radius: 18px;
+      box-shadow: 0 18px 35px rgba(15, 23, 42, 0.15);
+      padding: 3rem;
+      color: #0f172a;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      font-weight: 700;
+      color: #1e293b;
+    }
+    pre {
+      background-color: ${style.codeBlockBackground};
+      color: ${style.codeBlockText};
+      padding: 1.25rem;
+      border-radius: 14px;
+      overflow-x: auto;
+    }
+    code {
+      font-family: 'Fira Code', 'Cascadia Code', 'Source Code Pro', monospace;
+      background-color: rgba(148, 163, 184, 0.2);
+      padding: 0.1rem 0.3rem;
+      border-radius: 6px;
+    }
+    pre code {
+      background: none;
+      padding: 0;
+    }
+    a {
+      color: ${style.accentColor};
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    blockquote {
+      border-left: 4px solid #94a3b8;
+      padding-left: 1.25rem;
+      color: #475569;
+      font-style: italic;
+    }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+    }
+    table th, table td {
+      border: 1px solid #cbd5f5;
+      padding: 0.75rem;
+    }
+    img {
+      max-width: 100%;
+    }
+    ul {
+      padding-left: 1.5rem;
+    }
+    @media (max-width: 768px) {
+      .container {
+        padding: 1.75rem;
+      }
+    }
+  `;
+
+  if (!style.customCss) {
+    return base;
+  }
+
+  return `${base}\n${style.customCss}`;
+}
+
+function normalizeWidth(value: string | number | undefined): string | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `${value}px`;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  return undefined;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,4 @@
+export { renderMarkdownToHtml, RenderOptions } from './markdownRenderer.js';
+export { buildHtmlDocument } from './htmlTemplate.js';
+export { MarkdownConversionService } from './fileConversionService.js';
+export { openFileInBrowser } from './openInBrowser.js';

--- a/backend/src/markdownRenderer.ts
+++ b/backend/src/markdownRenderer.ts
@@ -1,0 +1,201 @@
+import { StyleAdjustOptions } from './configuration.js';
+import { buildHtmlDocument } from './htmlTemplate.js';
+
+export interface RenderOptions {
+  title?: string;
+  styleAdjustments?: StyleAdjustOptions;
+}
+
+interface RenderOutcome {
+  html: string;
+  detectedTitle?: string;
+}
+
+export function renderMarkdownToHtml(source: string, options: RenderOptions = {}): string {
+  const { html, detectedTitle } = renderBlocks(source);
+  const title = options.title ?? detectedTitle ?? 'Markdown Document';
+  return buildHtmlDocument({
+    title,
+    content: html,
+    style: options.styleAdjustments
+  });
+}
+
+function renderBlocks(markdown: string): RenderOutcome {
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+  const fragments: string[] = [];
+  let detectedTitle: string | undefined;
+  let index = 0;
+
+  while (index < lines.length) {
+    const current = lines[index];
+    if (current.trim().length === 0) {
+      index += 1;
+      continue;
+    }
+
+    if (isFence(current)) {
+      const { html, nextIndex } = consumeFence(lines, index);
+      fragments.push(html);
+      index = nextIndex;
+      continue;
+    }
+
+    const headingMatch = current.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const rawText = headingMatch[2].trim();
+      fragments.push(`<h${level}>${renderInline(rawText)}</h${level}>`);
+      if (!detectedTitle) {
+        detectedTitle = stripInlineFormatting(rawText);
+      }
+      index += 1;
+      continue;
+    }
+
+    if (/^([*-])\s+/.test(current)) {
+      const { html, nextIndex } = consumeList(lines, index);
+      fragments.push(html);
+      index = nextIndex;
+      continue;
+    }
+
+    if (current.startsWith('>')) {
+      const { html, nextIndex } = consumeBlockquote(lines, index);
+      fragments.push(html);
+      index = nextIndex;
+      continue;
+    }
+
+    if (/^([*_\-]){3,}$/.test(current.trim())) {
+      fragments.push('<hr />');
+      index += 1;
+      continue;
+    }
+
+    const { html, nextIndex } = consumeParagraph(lines, index);
+    fragments.push(html);
+    index = nextIndex;
+  }
+
+  return { html: fragments.join('\n'), detectedTitle };
+}
+
+function consumeFence(lines: string[], startIndex: number): { html: string; nextIndex: number } {
+  const buffer: string[] = [];
+  let index = startIndex + 1;
+  while (index < lines.length && !isFence(lines[index])) {
+    buffer.push(lines[index]);
+    index += 1;
+  }
+  if (index < lines.length && isFence(lines[index])) {
+    index += 1;
+  }
+  const code = buffer.join('\n');
+  return {
+    html: `<pre><code>${escapeHtml(code)}</code></pre>`,
+    nextIndex: index
+  };
+}
+
+function consumeList(lines: string[], startIndex: number): { html: string; nextIndex: number } {
+  const items: string[] = [];
+  let index = startIndex;
+  while (index < lines.length && /^([*-])\s+/.test(lines[index])) {
+    const itemText = lines[index].replace(/^([*-])\s+/, '');
+    items.push(`<li>${renderInline(itemText)}</li>`);
+    index += 1;
+  }
+  return {
+    html: `<ul>\n${items.join('\n')}\n</ul>`,
+    nextIndex: index
+  };
+}
+
+function consumeBlockquote(lines: string[], startIndex: number): { html: string; nextIndex: number } {
+  const collected: string[] = [];
+  let index = startIndex;
+  while (index < lines.length && lines[index].startsWith('>')) {
+    collected.push(lines[index].replace(/^>\s?/, ''));
+    index += 1;
+  }
+  return {
+    html: `<blockquote>${renderInline(collected.join(' '))}</blockquote>`,
+    nextIndex: index
+  };
+}
+
+function consumeParagraph(lines: string[], startIndex: number): { html: string; nextIndex: number } {
+  const collected: string[] = [];
+  let index = startIndex;
+  while (
+    index < lines.length &&
+    lines[index].trim().length > 0 &&
+    !isFence(lines[index]) &&
+    !/^(#{1,6})\s+/.test(lines[index]) &&
+    !/^([*-])\s+/.test(lines[index]) &&
+    !lines[index].startsWith('>') &&
+    !/^([*_\-]){3,}$/.test(lines[index].trim())
+  ) {
+    collected.push(lines[index]);
+    index += 1;
+  }
+  return {
+    html: `<p>${renderInline(collected.join(' '))}</p>`,
+    nextIndex: index
+  };
+}
+
+function isFence(line: string): boolean {
+  return line.trim().startsWith('```');
+}
+
+function renderInline(text: string): string {
+  const codeSegments: string[] = [];
+  let processed = text.replace(/`([^`]+)`/g, (_, segment) => {
+    const token = `@@CODE${codeSegments.length}@@`;
+    codeSegments.push(segment);
+    return token;
+  });
+
+  processed = escapeHtml(processed);
+
+  processed = processed.replace(/\[(.+?)\]\((.+?)\)/g, (_, label: string, url: string) => {
+    return `<a href="${escapeAttribute(url)}">${label}</a>`;
+  });
+  processed = processed.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  processed = processed.replace(/__(.+?)__/g, '<strong>$1</strong>');
+  processed = processed.replace(/\*(.+?)\*/g, '<em>$1</em>');
+  processed = processed.replace(/_(.+?)_/g, '<em>$1</em>');
+
+  codeSegments.forEach((segment, index) => {
+    const token = `@@CODE${index}@@`;
+    processed = processed.replace(token, `<code>${escapeHtml(segment)}</code>`);
+  });
+
+  return processed;
+}
+
+function stripInlineFormatting(text: string): string {
+  return text
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\[(.+?)\]\((.+?)\)/g, '$1')
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/__(.+?)__/g, '$1')
+    .replace(/\*(.+?)\*/g, '$1')
+    .replace(/_(.+?)_/g, '$1')
+    .trim();
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value);
+}

--- a/backend/src/openInBrowser.ts
+++ b/backend/src/openInBrowser.ts
@@ -1,0 +1,38 @@
+import { spawn } from 'child_process';
+import path from 'path';
+
+export function openFileInBrowser(filePath: string): void {
+  const absolute = path.resolve(filePath);
+  const platform = process.platform;
+  let command: string;
+  let args: string[];
+
+  if (platform === 'win32') {
+    command = 'cmd';
+    args = ['/c', 'start', '', quoteIfNeeded(absolute)];
+  } else if (platform === 'darwin') {
+    command = 'open';
+    args = [absolute];
+  } else {
+    command = 'xdg-open';
+    args = [absolute];
+  }
+
+  try {
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: 'ignore',
+      windowsVerbatimArguments: platform === 'win32'
+    });
+    child.unref();
+  } catch (error) {
+    throw new Error(`Failed to open browser for ${absolute}: ${(error as Error).message}`);
+  }
+}
+
+function quoteIfNeeded(value: string): string {
+  if (/\s/.test(value)) {
+    return `"${value}"`;
+  }
+  return value;
+}

--- a/backend/src/shims.d.ts
+++ b/backend/src/shims.d.ts
@@ -1,0 +1,4 @@
+declare module 'child_process';
+declare module 'fs';
+declare module 'path';
+declare const process: any;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/docs/commits/x20240420_1205.txt
+++ b/docs/commits/x20240420_1205.txt
@@ -1,0 +1,25 @@
+Stamp: x20240420_1205
+Node: N101
+Message: Initialize project scaffolding
+This file: docs/commits/x20240420_1205.txt
+
+Changed Files:
+docs/notes/x20240420_1200_planning.txt
+
+Per-file Notes:
++-----------------------------+--------------------------------------------------------------+
+| File                        | Notes                                                        |
++-----------------------------+--------------------------------------------------------------+
+| docs/notes/x20240420_1200_planning.txt | Created planning note with ASCII table covering roles and steps. |
++-----------------------------+--------------------------------------------------------------+
+
+Assumptions:
+- Planning note satisfies requirement for documenting steps before coding.
+
+Problems Since Last Commit:
+- None; initial scaffolding.
+
+Legend:
+- '+' marks table edges/intersections.
+- '|' separates columns.
+- '-' defines horizontal borders.

--- a/docs/commits/x20240420_1215.txt
+++ b/docs/commits/x20240420_1215.txt
@@ -1,0 +1,33 @@
+Stamp: x20240420_1215
+Node: N102
+Message: Introduce TypeScript renderer modules
+This file: docs/commits/x20240420_1215.txt
+
+Changed Files:
+backend/package.json
+backend/tsconfig.json
+backend/src/htmlTemplate.ts
+backend/src/index.ts
+backend/src/markdownRenderer.ts
+
+Per-file Notes:
++---------------------------+--------------------------------------------------------------------------+
+| File                      | Notes                                                                    |
++---------------------------+--------------------------------------------------------------------------+
+| backend/package.json      | Added project metadata, build script, and Markdown dependencies.         |
+| backend/tsconfig.json     | Configured compiler for strict CommonJS output.                          |
+| backend/src/htmlTemplate.ts | Implemented styled HTML wrapper with CSS and escaping helper.            |
+| backend/src/index.ts      | Re-exported rendering APIs for future CLI usage.                         |
+| backend/src/markdownRenderer.ts | Configured markdown-it with highlight.js and title derivation.          |
++---------------------------+--------------------------------------------------------------------------+
+
+Assumptions:
+- highlight.js with markdown-it suffices for syntax highlighting needs.
+
+Problems Since Last Commit:
+- npm install blocked by registry permissions; pending resolution but does not block TypeScript authoring.
+
+Legend:
+- '+' outlines table borders and intersections.
+- '|' separates columns.
+- '-' draws horizontal lines.

--- a/docs/commits/x20240420_1225.txt
+++ b/docs/commits/x20240420_1225.txt
@@ -1,0 +1,35 @@
+Stamp: x20240420_1225
+Node: N103
+Message: Add CLI pipeline and browser launching
+This file: docs/commits/x20240420_1225.txt
+
+Changed Files:
+backend/package.json
+backend/src/cli.ts
+backend/src/fileConversionService.ts
+backend/src/index.ts
+backend/src/markdownRenderer.ts
+backend/src/openInBrowser.ts
+
+Per-file Notes:
++-------------------------------+--------------------------------------------------------------------------+
+| File                          | Notes                                                                    |
++-------------------------------+--------------------------------------------------------------------------+
+| backend/package.json          | Declared CLI binary mapping to compiled entrypoint.                      |
+| backend/src/cli.ts            | Added argument parsing, conversion orchestration, and status logging.    |
+| backend/src/fileConversionService.ts | Implemented file IO service to convert Markdown to HTML outputs.         |
+| backend/src/index.ts          | Re-exported new services for external consumption.                       |
+| backend/src/markdownRenderer.ts | Corrected escaping path in highlight fallback helper.                    |
+| backend/src/openInBrowser.ts  | Added cross-platform routine to open generated HTML via system command.  |
++-------------------------------+--------------------------------------------------------------------------+
+
+Assumptions:
+- Manual argument parsing suffices for first release; additional flags can follow later.
+
+Problems Since Last Commit:
+- None beyond previously noted npm registry restriction.
+
+Legend:
+- '+' marks table corners and intersections.
+- '|' separates columns.
+- '-' draws horizontal rules.

--- a/docs/commits/x20240420_1235.txt
+++ b/docs/commits/x20240420_1235.txt
@@ -1,0 +1,31 @@
+Stamp: x20240420_1235
+Node: N104
+Message: Add packaging scripts and regression tests
+This file: docs/commits/x20240420_1235.txt
+
+Changed Files:
+backend/package.json
+backend/src/shims.d.ts
+tests/backend/markdownRenderer.test.mjs
+docs/notes/x20240420_1230_testing_plan.txt
+
+Per-file Notes:
++----------------------------------------+--------------------------------------------------------------------------+
+| File                                   | Notes                                                                    |
++----------------------------------------+--------------------------------------------------------------------------+
+| backend/package.json                   | Added test/build:exe scripts and pkg configuration.                      |
+| backend/src/shims.d.ts                 | Declared Node module shims to compile without external type packages.    |
+| tests/backend/markdownRenderer.test.mjs | Added node:test specs validating rendering and file conversion outputs.   |
+| docs/notes/x20240420_1230_testing_plan.txt | Documented testing and packaging focus with ASCII planning table.          |
++----------------------------------------+--------------------------------------------------------------------------+
+
+Assumptions:
+- Node built-in test runner is sufficient for verifying conversion logic.
+
+Problems Since Last Commit:
+- npm install remains blocked by registry permissions (highlight.js download denied).
+
+Legend:
+- '+' outlines table borders and intersections.
+- '|' separates columns.
+- '-' renders horizontal bars.

--- a/docs/commits/x20240420_1245.txt
+++ b/docs/commits/x20240420_1245.txt
@@ -1,0 +1,31 @@
+Stamp: x20240420_1245
+Node: N105
+Message: Replace external renderer with internal parser
+This file: docs/commits/x20240420_1245.txt
+
+Changed Files:
+backend/package.json
+backend/src/htmlTemplate.ts
+backend/src/markdownRenderer.ts
+docs/notes/x20240420_1240_dependency_plan.txt
+
+Per-file Notes:
++-----------------------------------------+--------------------------------------------------------------------------+
+| File                                    | Notes                                                                    |
++-----------------------------------------+--------------------------------------------------------------------------+
+| backend/package.json                    | Removed runtime dependencies after moving to custom renderer.            |
+| backend/src/htmlTemplate.ts             | Simplified CSS bundle now that highlight-specific styles are unused.     |
+| backend/src/markdownRenderer.ts         | Implemented lightweight Markdown parser covering key block/inline cases. |
+| docs/notes/x20240420_1240_dependency_plan.txt | Logged dependency strategy pivot with ASCII summary.                         |
++-----------------------------------------+--------------------------------------------------------------------------+
+
+Assumptions:
+- Custom parser delivering headings, lists, blockquotes, code blocks is sufficient for MVP.
+
+Problems Since Last Commit:
+- None; removal of blocked packages resolved npm install issues for renderer logic.
+
+Legend:
+- '+' marks table edges and intersections.
+- '|' separates column data.
+- '-' renders horizontal separators.

--- a/docs/commits/x20240420_1255.txt
+++ b/docs/commits/x20240420_1255.txt
@@ -1,0 +1,27 @@
+Stamp: x20240420_1255
+Node: N106
+Message: Make packaging tooling optional
+This file: docs/commits/x20240420_1255.txt
+
+Changed Files:
+backend/package.json
+docs/notes/x20240420_1250_pkg_plan.txt
+
+Per-file Notes:
++------------------------------------+--------------------------------------------------------------------------+
+| File                               | Notes                                                                    |
++------------------------------------+--------------------------------------------------------------------------+
+| backend/package.json               | Swapped build:exe script to npx pkg and removed direct dev dependency.   |
+| docs/notes/x20240420_1250_pkg_plan.txt | Logged packaging approach emphasizing optional tooling.                    |
++------------------------------------+--------------------------------------------------------------------------+
+
+Assumptions:
+- Developers can install pkg separately when building the executable.
+
+Problems Since Last Commit:
+- npm install still blocked: registry forbids fetching typescript package in this environment.
+
+Legend:
+- '+' shapes table intersections.
+- '|' separates column data.
+- '-' renders horizontal boundaries.

--- a/docs/commits/x20240420_1305.txt
+++ b/docs/commits/x20240420_1305.txt
@@ -1,0 +1,29 @@
+Stamp: x20240420_1305
+Node: N107
+Message: Document workflows and update packaging log
+This file: docs/commits/x20240420_1305.txt
+
+Changed Files:
+README.md
+docs/notes/x20240420_1300_docs_plan.txt
+docs/commits/x20240420_1255.txt
+
+Per-file Notes:
++------------------------------------+--------------------------------------------------------------------------+
+| File                               | Notes                                                                    |
++------------------------------------+--------------------------------------------------------------------------+
+| README.md                          | Added project overview, CLI usage, testing, and packaging guidance.      |
+| docs/notes/x20240420_1300_docs_plan.txt | Captured documentation goals in ASCII planning table.                       |
+| docs/commits/x20240420_1255.txt    | Updated problem log to reflect TypeScript registry restriction.          |
++------------------------------------+--------------------------------------------------------------------------+
+
+Assumptions:
+- Contributors will consult README for build/install instructions.
+
+Problems Since Last Commit:
+- npm install continues failing for typescript downloads in this sandbox environment.
+
+Legend:
+- '+' shapes table intersections.
+- '|' separates column data.
+- '-' renders horizontal boundaries.

--- a/docs/commits/x20240420_1315.txt
+++ b/docs/commits/x20240420_1315.txt
@@ -1,0 +1,29 @@
+Stamp: x20240420_1315
+Node: N108
+Message: Clean CLI imports and ignore build artefacts
+This file: docs/commits/x20240420_1315.txt
+
+Changed Files:
+backend/src/cli.ts
+.gitignore
+docs/notes/x20240420_1310_build_clean.txt
+
+Per-file Notes:
++------------------------------------+--------------------------------------------------------------------------+
+| File                               | Notes                                                                    |
++------------------------------------+--------------------------------------------------------------------------+
+| backend/src/cli.ts                 | Dropped process module import to use global shim-friendly access.        |
+| .gitignore                         | Ignored backend dist outputs and node_modules for cleanliness.           |
+| docs/notes/x20240420_1310_build_clean.txt | Captured rationale for ignoring build artefacts via ASCII table.         |
++------------------------------------+--------------------------------------------------------------------------+
+
+Assumptions:
+- Global process shim suffices for CLI runtime in Node.
+
+Problems Since Last Commit:
+- None; build and tests now succeed locally using global TypeScript tooling.
+
+Legend:
+- '+' shapes table intersections.
+- '|' separates column data.
+- '-' renders horizontal boundaries.

--- a/docs/commits/x20240420_1330.txt
+++ b/docs/commits/x20240420_1330.txt
@@ -1,0 +1,30 @@
+Stamp: x20240420_1330
+Node: N109
+Message: Introduce configuration loader scaffold
+This file: docs/commits/x20240420_1330.txt
+
+Changed Files:
+backend/src/configuration.ts
+tests/backend/configuration.test.mjs
+docs/notes/x20240420_1325_config_plan.txt
+
+Per-file Notes:
++-------------------------------------------+--------------------------------------------------------------------------+
+| File                                      | Notes                                                                    |
++-------------------------------------------+--------------------------------------------------------------------------+
+| backend/src/configuration.ts              | Added loader to discover config near executable and sanitize style fields. |
+| tests/backend/configuration.test.mjs      | Added coverage verifying parsing normalization and width conversion.      |
+| docs/notes/x20240420_1325_config_plan.txt | Marked schema drafting step as completed in planning table.               |
++-------------------------------------------+--------------------------------------------------------------------------+
+
+Assumptions:
+- Packaging tools will place mdviewer.config.json alongside the executable.
+- Consumers prefer string-based CSS values; numeric widths convert to px.
+
+Problems Since Last Commit:
+- None observed.
+
+Legend:
+- '+' marks table borders/intersections.
+- '|' separates columns.
+- '-' renders horizontal rules.

--- a/docs/commits/x20240420_1340.txt
+++ b/docs/commits/x20240420_1340.txt
@@ -1,0 +1,32 @@
+Stamp: x20240420_1340
+Node: N110
+Message: Allow HTML template to respect style adjustments
+This file: docs/commits/x20240420_1340.txt
+
+Changed Files:
+backend/src/htmlTemplate.ts
+backend/src/markdownRenderer.ts
+tests/backend/markdownRenderer.test.mjs
+docs/notes/x20240420_1325_config_plan.txt
+
+Per-file Notes:
++-------------------------------------------+--------------------------------------------------------------------------+
+| File                                      | Notes                                                                    |
++-------------------------------------------+--------------------------------------------------------------------------+
+| backend/src/htmlTemplate.ts               | Swapped static CSS for configurable composer honoring style overrides.    |
+| backend/src/markdownRenderer.ts           | Threaded optional styleAdjustments through to HTML builder.               |
+| tests/backend/markdownRenderer.test.mjs   | Added regression ensuring CSS customizations surface in output.          |
+| docs/notes/x20240420_1325_config_plan.txt | Recorded completion of style override implementation step.              |
++-------------------------------------------+--------------------------------------------------------------------------+
+
+Assumptions:
+- Custom CSS snippets should append after base styles for easy overrides.
+- Width overrides accept px strings or plain numbers convertible to px.
+
+Problems Since Last Commit:
+- None.
+
+Legend:
+- '+' marks table edges and intersections.
+- '|' separates columns.
+- '-' draws horizontal dividers.

--- a/docs/commits/x20240420_1350.txt
+++ b/docs/commits/x20240420_1350.txt
@@ -1,0 +1,32 @@
+Stamp: x20240420_1350
+Node: N111
+Message: Wire CLI and service to configuration loader
+This file: docs/commits/x20240420_1350.txt
+
+Changed Files:
+backend/src/cli.ts
+backend/src/fileConversionService.ts
+tests/backend/markdownRenderer.test.mjs
+docs/notes/x20240420_1325_config_plan.txt
+
+Per-file Notes:
++-------------------------------------------+--------------------------------------------------------------------------+
+| File                                      | Notes                                                                    |
++-------------------------------------------+--------------------------------------------------------------------------+
+| backend/src/cli.ts                        | Load config beside executable, report path, and handle load failures.     |
+| backend/src/fileConversionService.ts      | Accept injected config and forward style overrides to renderer.          |
+| tests/backend/markdownRenderer.test.mjs   | Added regression verifying service honors injected style config.        |
+| docs/notes/x20240420_1325_config_plan.txt | Noted completion of CLI loading milestone.                              |
++-------------------------------------------+--------------------------------------------------------------------------+
+
+Assumptions:
+- Config load failures should stop execution before file conversion occurs.
+- Service consumers may mutate provided config, so constructor clones it.
+
+Problems Since Last Commit:
+- None.
+
+Legend:
+- '+' outlines table borders.
+- '|' separates columns.
+- '-' forms horizontal dividers.

--- a/docs/commits/x20240420_1400.txt
+++ b/docs/commits/x20240420_1400.txt
@@ -1,0 +1,32 @@
+Stamp: x20240420_1400
+Node: N112
+Message: Document configuration workflow and ship default theme
+This file: docs/commits/x20240420_1400.txt
+
+Changed Files:
+README.md
+backend/package.json
+mdviewer.config.json
+docs/notes/x20240420_1325_config_plan.txt
+
+Per-file Notes:
++-------------------------------------------+--------------------------------------------------------------------------+
+| File                                      | Notes                                                                    |
++-------------------------------------------+--------------------------------------------------------------------------+
+| README.md                                 | Added configuration section detailing supported style fields and usage.  |
+| backend/package.json                      | Ensured exe build copies config next to binary for drag-and-drop usage.  |
+| mdviewer.config.json                      | Introduced default theme demonstrating accent, fonts, and hover styling. |
+| docs/notes/x20240420_1325_config_plan.txt | Closed documentation milestone in planning tracker.                      |
++-------------------------------------------+--------------------------------------------------------------------------+
+
+Assumptions:
+- Providing a default config helps users discover customization quickly.
+- Copying config during packaging is sufficient without embedding via pkg assets.
+
+Problems Since Last Commit:
+- None.
+
+Legend:
+- '+' builds table borders and intersections.
+- '|' separates columns.
+- '-' forms horizontal dividers.

--- a/docs/notes/x20240420_1200_planning.txt
+++ b/docs/notes/x20240420_1200_planning.txt
@@ -1,0 +1,16 @@
+Current & Future Work Overview (ASCII Table)
++-------------------------+---------------------------------------------------------------+
+| Segment                 | Notes                                                         |
++-------------------------+---------------------------------------------------------------+
+| Current Steps           | bootstrap repo structure; align docs folders; prepare testing |
+| Future Steps            | implement markdown renderer; wire CLI; add packaging via pkg  |
+| Self-Considerations     | ensure ts/JS toolchain fits pkg; plan for Windows behaviours   |
+| Role: QA                | demand unit tests for converter; ensure HTML output validated  |
+| Role: Dev Principal     | enforce TypeScript structure; align with repo conventions      |
+| Role: DevOps            | verify pkg build reproducibility; script packaging command     |
+| Role: High Dreaming Dev | envision theme customization; potential GUI overlay            |
++-------------------------+---------------------------------------------------------------+
+Legend:
+- '+' denotes table corners and intersections.
+- '|' separates table columns.
+- '-' creates horizontal borders.

--- a/docs/notes/x20240420_1230_testing_plan.txt
+++ b/docs/notes/x20240420_1230_testing_plan.txt
@@ -1,0 +1,16 @@
+Testing & Packaging Outlook
++-------------------------+-------------------------------------------------------------------+
+| Focus                   | Details                                                           |
++-------------------------+-------------------------------------------------------------------+
+| Current Steps           | Add node:test checks consuming compiled dist outputs.             |
+| Future Steps            | Script pkg build for Windows executable delivery.                 |
+| Self-Considerations     | Manage missing registry packages; document blocked installs.      |
+| Role: QA                | Validate HTML generation via assertions on compiled output.       |
+| Role: Dev Principal     | Ensure CLI stays scriptable for automation contexts.              |
+| Role: DevOps            | Provide reproducible build: npm run build && pkg invocation.      |
+| Role: High Dreaming Dev | Picture pipeline for bundling multiple themes per exe.            |
++-------------------------+-------------------------------------------------------------------+
+Legend:
+- '+' draws edges and intersections.
+- '|' partitions columns.
+- '-' underlines header rows.

--- a/docs/notes/x20240420_1240_dependency_plan.txt
+++ b/docs/notes/x20240420_1240_dependency_plan.txt
@@ -1,0 +1,16 @@
+Dependency Strategy Shift
++-------------------------+-------------------------------------------------------------------+
+| Focus                   | Details                                                           |
++-------------------------+-------------------------------------------------------------------+
+| Current Steps           | Replace external markdown packages with internal renderer.        |
+| Future Steps            | Consider reintroducing libraries when registry access returns.    |
+| Self-Considerations     | Balance feature coverage with maintainable custom parser.         |
+| Role: QA                | Re-run tests ensuring new renderer meets expectations.            |
+| Role: Dev Principal     | Review parser readability and extensibility.                      |
+| Role: DevOps            | Appreciate zero third-party runtime dependencies.                 |
+| Role: High Dreaming Dev | Dreams about plugin hooks layered atop custom parser.             |
++-------------------------+-------------------------------------------------------------------+
+Legend:
+- '+' draws table borders and intersections.
+- '|' separates columns.
+- '-' underlines header rows.

--- a/docs/notes/x20240420_1250_pkg_plan.txt
+++ b/docs/notes/x20240420_1250_pkg_plan.txt
@@ -1,0 +1,16 @@
+Packaging Adjustments
++-------------------------+-------------------------------------------------------------------+
+| Focus                   | Details                                                           |
++-------------------------+-------------------------------------------------------------------+
+| Current Steps           | Shift build script to use npx pkg without pinned dependency.       |
+| Future Steps            | Document prerequisite for developers to install pkg globally.      |
+| Self-Considerations     | Ensure npm install succeeds even without external registry access. |
+| Role: QA                | No runtime impact; keep verifying CLI after packaging.             |
+| Role: Dev Principal     | Prefers optional tooling to reduce friction.                       |
+| Role: DevOps            | Will update CI to pre-install pkg before invoking build:exe.       |
+| Role: High Dreaming Dev | Imagines wrappers for selecting multiple pkg targets.              |
++-------------------------+-------------------------------------------------------------------+
+Legend:
+- '+' draws table edges and intersections.
+- '|' separates columns.
+- '-' renders horizontal dividers.

--- a/docs/notes/x20240420_1300_docs_plan.txt
+++ b/docs/notes/x20240420_1300_docs_plan.txt
@@ -1,0 +1,16 @@
+Documentation Update Plan
++-------------------------+-------------------------------------------------------------------+
+| Focus                   | Details                                                           |
++-------------------------+-------------------------------------------------------------------+
+| Current Steps           | Add README summarizing build, test, and packaging workflows.       |
+| Future Steps            | Consider tutorial GIFs once UI stabilizes.                         |
+| Self-Considerations     | Keep documentation aligned with custom renderer capabilities.      |
+| Role: QA                | Wants documentation to outline regression test commands.           |
+| Role: Dev Principal     | Ensures README reflects repository structure and scripts.          |
+| Role: DevOps            | Appreciates clarity on npm install prerequisites.                  |
+| Role: High Dreaming Dev | Envisions docs covering theme customization pipeline.              |
++-------------------------+-------------------------------------------------------------------+
+Legend:
+- '+' delineates table borders and intersections.
+- '|' separates columns.
+- '-' underlines header rows.

--- a/docs/notes/x20240420_1310_build_clean.txt
+++ b/docs/notes/x20240420_1310_build_clean.txt
@@ -1,0 +1,16 @@
+Build Cleanliness Update
++-------------------------+-------------------------------------------------------------------+
+| Focus                   | Details                                                           |
++-------------------------+-------------------------------------------------------------------+
+| Current Steps           | Remove process import to rely on global shim and ignore build artefacts. |
+| Future Steps            | Consider dedicated clean script for dist removal post-tests.       |
+| Self-Considerations     | Keep repository tidy despite local build outputs.                  |
+| Role: QA                | Confirms CLI uses global process without module dependency.        |
+| Role: Dev Principal     | Approves .gitignore covering dist and node_modules.                |
+| Role: DevOps            | Suggests CI wipe dist folders before packaging.                    |
+| Role: High Dreaming Dev | Imagines advanced build pipeline generating cross-target outputs.  |
++-------------------------+-------------------------------------------------------------------+
+Legend:
+- '+' draws table edges and intersections.
+- '|' separates columns.
+- '-' underlines header rows.

--- a/docs/notes/x20240420_1325_config_plan.txt
+++ b/docs/notes/x20240420_1325_config_plan.txt
@@ -1,0 +1,34 @@
+# Config Integration Plan
+
+Current Steps:
+```
++------------+-----------------------+-------------------+
+| Step Index | Description           | Status            |
++------------+-----------------------+-------------------+
+| 01         | Draft config schema   | done              |
+| 02         | Load config in CLI    | done              |
+| 03         | Apply style overrides | done              |
+| 04         | Document usage        | done              |
++------------+-----------------------+-------------------+
+```
+Legend: `+` and `|` mark table borders.
+
+Future Steps:
+```
+Step---->Outcome---->Benefit
+  1          2           A
+  2          3           B
+```
+Legend: `-` indicates horizontal connectors, `>` arrow direction, spaces separate columns.
+
+Self-Considerations:
+- Validate default behavior without config file.
+- Ensure style overrides are sanitized.
+- Provide helpful error messaging when config parsing fails.
+
+Role Perspectives:
+- QA: Need deterministic defaults and tests for config parsing.
+- Dev Principal: Config loader should be modular for future options.
+- DevOps: Config file must live beside executable for packaging.
+- Dreamer: Could later support multiple themes.
+- Typical Client: Wants easy way to tweak colors without editing code.

--- a/docs/perspe/N101.md
+++ b/docs/perspe/N101.md
@@ -1,0 +1,19 @@
+# Node N101 Perspectives
+
++----------------------+----------------------------------------------------------+
+| Perspective          | Key Thoughts                                             |
++----------------------+----------------------------------------------------------+
+| QA                   | Need traceable test plan once functionality lands.       |
+| Dev                  | Establish TypeScript toolchain before implementation.    |
+| Junior Dev           | Follow folder conventions; learn commit documentation.   |
+| Dreamer Dev          | Visualize theme library for Markdown outputs.            |
+| Typical Client       | Wants drop-to-open experience with minimal setup.        |
+| Dev Principal        | Ensure architecture allows future extensions.            |
+| DevOps               | Plan deterministic build into `.exe` using pkg.          |
+| High Dreaming Feature Creator | Imagine plugin ecosystem for styling presets.            |
++----------------------+----------------------------------------------------------+
+
+Legend:
+- '+' depicts table borders and intersections.
+- '|' separates perspective name from notes.
+- '-' creates horizontal border lines.

--- a/docs/perspe/N102.md
+++ b/docs/perspe/N102.md
@@ -1,0 +1,19 @@
+# Node N102 Perspectives
+
++----------------------+------------------------------------------------------------------+
+| Perspective          | Thoughts                                                         |
++----------------------+------------------------------------------------------------------+
+| QA                   | Request snapshot tests to lock in HTML output.                   |
+| Dev                  | Rendering module ready for CLI integration.                      |
+| Junior Dev           | Understand markdown-it plugin configuration.                     |
+| Dreamer Dev          | Imagine theming toggles for future release.                      |
+| Typical Client       | Expects polished HTML layout from the start.                     |
+| Dev Principal        | Happy with separation between template and renderer.             |
+| DevOps               | Notes dependencies to vendor in executable bundle.               |
+| High Dreaming Feature Creator | Sees potential for sharing themes and custom CSS overrides. |
++----------------------+------------------------------------------------------------------+
+
+Legend:
+- '+' builds border intersections.
+- '|' delineates table columns.
+- '-' forms horizontal separators.

--- a/docs/perspe/N103.md
+++ b/docs/perspe/N103.md
@@ -1,0 +1,19 @@
+# Node N103 Perspectives
+
++----------------------+---------------------------------------------------------------------+
+| Perspective          | Thoughts                                                            |
++----------------------+---------------------------------------------------------------------+
+| QA                   | Will plan CLI argument tests and browser invocation mocks.           |
+| Dev                  | Confident about service abstraction enabling reuse.                  |
+| Junior Dev           | Learned how to spawn processes cross-platform.                       |
+| Dreamer Dev          | Envisions drag-and-drop UI wrapper in future GUI release.            |
+| Typical Client       | Expects immediate browser launch after conversion.                   |
+| Dev Principal        | Appreciates separation between CLI, services, and rendering layers.  |
+| DevOps               | Notes need to document windowsVerbatimArguments usage for pkg.       |
+| High Dreaming Feature Creator | Dreams about queueing batch conversions via CLI flags.              |
++----------------------+---------------------------------------------------------------------+
+
+Legend:
+- '+' forms table borders and intersections.
+- '|' separates the perspective label from commentary.
+- '-' creates horizontal separators.

--- a/docs/perspe/N104.md
+++ b/docs/perspe/N104.md
@@ -1,0 +1,19 @@
+# Node N104 Perspectives
+
++----------------------+--------------------------------------------------------------------------+
+| Perspective          | Insights                                                                 |
++----------------------+--------------------------------------------------------------------------+
+| QA                   | Happy to see automated tests on renderer and file outputs.               |
+| Dev                  | Enjoys built-in node:test approach avoiding extra deps.                  |
+| Junior Dev           | Learns how pkg integrates with TypeScript build artefacts.               |
+| Dreamer Dev          | Imagines future suite covering themes and accessibility.                 |
+| Typical Client       | Appreciates documented path to Windows executable.                       |
+| Dev Principal        | Notes shim strategy to keep builds moving under registry constraints.    |
+| DevOps               | Plans CI steps: npm install, npm run build, npm run build:exe.           |
+| High Dreaming Feature Creator | Visualizes multi-platform packaging once restrictions lift.              |
++----------------------+--------------------------------------------------------------------------+
+
+Legend:
+- '+' forms table borders and intersections.
+- '|' separates perspective column from commentary.
+- '-' creates horizontal separators.

--- a/docs/perspe/N105.md
+++ b/docs/perspe/N105.md
@@ -1,0 +1,19 @@
+# Node N105 Perspectives
+
++----------------------+--------------------------------------------------------------------------+
+| Perspective          | Thoughts                                                                 |
++----------------------+--------------------------------------------------------------------------+
+| QA                   | Plans new assertions ensuring custom parser matches expectations.        |
+| Dev                  | Appreciates zero-dependency runtime with controllable parser behavior.   |
+| Junior Dev           | Learns techniques for building simple markdown transformations.          |
+| Dreamer Dev          | Imagines extending parser with plugin hooks and theme toggles.           |
+| Typical Client       | Sees benefit in offline-ready executable without npm downloads.          |
+| Dev Principal        | Notes easier licensing/compliance by owning parsing logic.               |
+| DevOps               | Happy about lighter packaging since no npm modules are bundled.          |
+| High Dreaming Feature Creator | Dreams of pipeline to add advanced syntax (tables, mermaid) gradually. |
++----------------------+--------------------------------------------------------------------------+
+
+Legend:
+- '+' forms table borders and intersections.
+- '|' separates columns.
+- '-' creates horizontal dividers.

--- a/docs/perspe/N106.md
+++ b/docs/perspe/N106.md
@@ -1,0 +1,19 @@
+# Node N106 Perspectives
+
++----------------------+--------------------------------------------------------------------------+
+| Perspective          | Thoughts                                                                 |
++----------------------+--------------------------------------------------------------------------+
+| QA                   | Notes no test impact from packaging tweak.                               |
+| Dev                  | Enjoys leaner install process without pkg dependency.                    |
+| Junior Dev           | Learns about using npx for optional tooling.                              |
+| Dreamer Dev          | Imagines UI toggle for selecting pkg targets interactively.              |
+| Typical Client       | Still receives executable instructions without extra setup hurdles.      |
+| Dev Principal        | Approves reducing dependency surface area.                               |
+| DevOps               | Will pre-install pkg in CI images when needed.                            |
+| High Dreaming Feature Creator | Considers future cross-platform packaging strategies.                 |
++----------------------+--------------------------------------------------------------------------+
+
+Legend:
+- '+' forms table borders and intersections.
+- '|' separates columns.
+- '-' builds horizontal separators.

--- a/docs/perspe/N107.md
+++ b/docs/perspe/N107.md
@@ -1,0 +1,19 @@
+# Node N107 Perspectives
+
++----------------------+--------------------------------------------------------------------------+
+| Perspective          | Thoughts                                                                 |
++----------------------+--------------------------------------------------------------------------+
+| QA                   | Appreciates README documenting how to run tests.                          |
+| Dev                  | Happy that workflow details are centralized for newcomers.                |
+| Junior Dev           | Gains clarity on how to package and execute the CLI.                      |
+| Dreamer Dev          | Imagines future docs with screenshots and animated demos.                 |
+| Typical Client       | Understands drag-and-drop usage and prerequisites.                        |
+| Dev Principal        | Values accurate record of registry limitations in commit log.            |
+| DevOps               | Notes README instructions to prep CI with TypeScript and pkg.            |
+| High Dreaming Feature Creator | Sees documentation as foundation for future feature showcases.           |
++----------------------+--------------------------------------------------------------------------+
+
+Legend:
+- '+' forms table borders and intersections.
+- '|' separates columns.
+- '-' creates horizontal separators.

--- a/docs/perspe/N108.md
+++ b/docs/perspe/N108.md
@@ -1,0 +1,19 @@
+# Node N108 Perspectives
+
++----------------------+--------------------------------------------------------------------------+
+| Perspective          | Thoughts                                                                 |
++----------------------+--------------------------------------------------------------------------+
+| QA                   | Notes tests now run cleanly after global process adjustment.              |
+| Dev                  | Appreciates ignoring build artefacts to keep repo tidy.                   |
+| Junior Dev           | Learns about relying on Node globals instead of explicit process import.  |
+| Dreamer Dev          | Imagines future script to auto-clean dist after packaging.                |
+| Typical Client       | Unaffected but benefits from stable CLI build.                            |
+| Dev Principal        | Supports using .gitignore to prevent accidental binary commits.           |
+| DevOps               | Plans CI cleanup steps aligned with new ignore list.                      |
+| High Dreaming Feature Creator | Sees pathway to multi-target builds without cluttering repo.            |
++----------------------+--------------------------------------------------------------------------+
+
+Legend:
+- '+' forms table borders and intersections.
+- '|' separates columns.
+- '-' creates horizontal separators.

--- a/docs/perspe/N109.md
+++ b/docs/perspe/N109.md
@@ -1,0 +1,19 @@
+# Node N109 Perspectives
+
++------------------------------+----------------------------------------------------------------------------+
+| Perspective                  | Thoughts                                                                   |
++------------------------------+----------------------------------------------------------------------------+
+| QA                           | Appreciates deterministic search order and validation errors for bad JSON. |
+| Dev                          | Likes modular config loader ready for future options.                      |
+| Junior Dev                   | Learns how to locate resources relative to executable and script paths.    |
+| Dreamer Dev                  | Envisions theme packs dropping JSON beside the binary.                     |
+| Typical Client               | Sees promise of tweaking colors without editing source files.              |
+| Dev Principal                | Notes cloning defaults prevents shared mutable state bugs.                 |
+| DevOps                       | Confident packaging can ship config alongside build artifacts.             |
+| High Dreaming Feature Creator | Imagines remote sync of configs for teams.                                 |
++------------------------------+----------------------------------------------------------------------------+
+
+Legend:
+- '+' forms table borders/intersections.
+- '|' separates columns.
+- '-' provides horizontal dividers.

--- a/docs/perspe/N110.md
+++ b/docs/perspe/N110.md
@@ -1,0 +1,19 @@
+# Node N110 Perspectives
+
++------------------------------+----------------------------------------------------------------------------+
+| Perspective                  | Thoughts                                                                   |
++------------------------------+----------------------------------------------------------------------------+
+| QA                           | Values test coverage confirming CSS overrides propagate to output.         |
+| Dev                          | Happy the template now composes styles dynamically.                        |
+| Junior Dev                   | Understands how to thread options through renderer layers.                |
+| Dreamer Dev                  | Imagines user-selectable themes toggled via config.                        |
+| Typical Client               | Anticipates tweaking width/colors without manual HTML edits.               |
+| Dev Principal                | Notes separation of concerns between config parsing and HTML generation.   |
+| DevOps                       | Considers shipping theme presets as optional JSON files.                   |
+| High Dreaming Feature Creator | Dreams of marketplace of shareable MdViewer themes.                       |
++------------------------------+----------------------------------------------------------------------------+
+
+Legend:
+- '+' forms table intersections and borders.
+- '|' separates columns.
+- '-' draws horizontal separators.

--- a/docs/perspe/N111.md
+++ b/docs/perspe/N111.md
@@ -1,0 +1,19 @@
+# Node N111 Perspectives
+
++------------------------------+----------------------------------------------------------------------------+
+| Perspective                  | Thoughts                                                                   |
++------------------------------+----------------------------------------------------------------------------+
+| QA                           | Glad CLI halts when config parsing fails, preventing silent misconfig.     |
+| Dev                          | Enjoys dependency injection of config for easier testing and reuse.        |
+| Junior Dev                   | Learns why constructors clone mutable configuration objects.               |
+| Dreamer Dev                  | Imagines UI slider that rewrites the JSON config next to the exe.          |
+| Typical Client               | Appreciates seeing which config file is in use when running the tool.     |
+| Dev Principal                | Notes separation of config discovery from conversion logic.                |
+| DevOps                       | Plans to ship default config template beside packaged binary.              |
+| High Dreaming Feature Creator | Dreams about syncing config via cloud for multi-device consistency.       |
++------------------------------+----------------------------------------------------------------------------+
+
+Legend:
+- '+' builds table borders and intersections.
+- '|' separates columns.
+- '-' produces horizontal separators.

--- a/docs/perspe/N112.md
+++ b/docs/perspe/N112.md
@@ -1,0 +1,19 @@
+# Node N112 Perspectives
+
++------------------------------+----------------------------------------------------------------------------+
+| Perspective                  | Thoughts                                                                   |
++------------------------------+----------------------------------------------------------------------------+
+| QA                           | Notes docs clarify expected config placement and supported keys.           |
+| Dev                          | Appreciates automated copy step keeping config next to packaged exe.       |
+| Junior Dev                   | Learns how documentation ties into packaging scripts.                      |
+| Dreamer Dev                  | Imagines curated theme gallery shipping as alternate JSON files.           |
+| Typical Client               | Grateful for ready-to-use theme without manual tweaking.                   |
+| Dev Principal                | Happy that README captures configuration contract for future updates.      |
+| DevOps                       | Plans release pipelines that bundle config alongside binary artifacts.     |
+| High Dreaming Feature Creator | Dreams of CLI switches to swap between multiple config presets.           |
++------------------------------+----------------------------------------------------------------------------+
+
+Legend:
+- '+' builds table borders and intersections.
+- '|' separates columns.
+- '-' draws horizontal dividers.

--- a/mdviewer.config.json
+++ b/mdviewer.config.json
@@ -1,0 +1,12 @@
+{
+  "style": {
+    "accentColor": "#6366f1",
+    "backgroundColor": "#f8fafc",
+    "backgroundGradient": "radial-gradient(circle at top, #ffffff 0%, #f8fafc 55%, #e2e8f0 100%)",
+    "baseFontFamily": "'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+    "codeBlockBackground": "#111827",
+    "codeBlockText": "#f8fafc",
+    "containerMaxWidth": "860px",
+    "customCss": ".container h1 { letter-spacing: 0.02em; }\n.container a:hover { color: #4338ca; }"
+  }
+}

--- a/tests/backend/configuration.test.mjs
+++ b/tests/backend/configuration.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { loadConfiguration, CONFIG_FILE_NAME } from '../../backend/dist/configuration.js';
+
+test('loadConfiguration reads explicit file and normalizes values', async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'mdviewer-config-'));
+  const configPath = path.join(directory, CONFIG_FILE_NAME);
+  await fs.writeFile(configPath, JSON.stringify({
+    style: {
+      accentColor: '#123456',
+      containerMaxWidth: 820,
+      customCss: '.custom { color: red; }'
+    }
+  }), 'utf8');
+
+  const { config, path: detectedPath } = loadConfiguration({ explicitPath: configPath });
+
+  assert.strictEqual(detectedPath, configPath);
+  assert.ok(config.style);
+  assert.strictEqual(config.style.accentColor, '#123456');
+  assert.strictEqual(config.style.containerMaxWidth, '820px');
+  assert.strictEqual(config.style.customCss, '.custom { color: red; }');
+});
+
+test('loadConfiguration accepts empty style definitions', async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'mdviewer-config-empty-'));
+  const configPath = path.join(directory, CONFIG_FILE_NAME);
+  await fs.writeFile(configPath, JSON.stringify({ style: {} }), 'utf8');
+
+  const { config } = loadConfiguration({ explicitPath: configPath });
+  assert.ok(config.style);
+  assert.strictEqual(Object.keys(config.style ?? {}).length, 0);
+});

--- a/tests/backend/markdownRenderer.test.mjs
+++ b/tests/backend/markdownRenderer.test.mjs
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { renderMarkdownToHtml } from '../../backend/dist/markdownRenderer.js';
+import { MarkdownConversionService } from '../../backend/dist/fileConversionService.js';
+
+test('renderMarkdownToHtml renders headings and body', () => {
+  const markdown = '# Sample Title\n\nContent paragraph.';
+  const html = renderMarkdownToHtml(markdown);
+  assert.ok(html.includes('<h1>Sample Title</h1>'));
+  assert.ok(html.includes('<p>Content paragraph.</p>'));
+  assert.ok(html.includes('<title>Sample Title</title>'));
+});
+
+test('renderMarkdownToHtml falls back to generic title', () => {
+  const markdown = 'Just text without heading';
+  const html = renderMarkdownToHtml(markdown);
+  assert.ok(html.includes('<title>Markdown Document</title>'));
+});
+
+test('renderMarkdownToHtml applies style adjustments', () => {
+  const markdown = '# Heading\n\nBody';
+  const html = renderMarkdownToHtml(markdown, {
+    styleAdjustments: {
+      accentColor: '#ff4500',
+      containerMaxWidth: '720px',
+      customCss: '.demo { margin: 0; }'
+    }
+  });
+
+  assert.ok(html.includes('#ff4500'));
+  assert.ok(html.includes('max-width: 720px'));
+  assert.ok(html.includes('.demo { margin: 0; }'));
+});
+
+test('MarkdownConversionService writes HTML next to source file', async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'mdviewer-test-'));
+  const sourcePath = path.join(directory, 'note.md');
+  await fs.writeFile(sourcePath, '# Note\n\nTesting.');
+
+  const service = new MarkdownConversionService();
+  const summary = await service.convertFile(sourcePath);
+
+  assert.strictEqual(summary.outputPath, path.join(directory, 'note.html'));
+  const exists = await fs.stat(summary.outputPath);
+  assert.ok(exists.isFile());
+
+  const html = await fs.readFile(summary.outputPath, 'utf8');
+  assert.ok(html.includes('<h1>Note</h1>'));
+});
+
+test('MarkdownConversionService applies configuration styles', async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'mdviewer-configured-'));
+  const sourcePath = path.join(directory, 'styled.md');
+  await fs.writeFile(sourcePath, '# Styled');
+
+  const service = new MarkdownConversionService({
+    config: {
+      style: {
+        accentColor: '#00aa88'
+      }
+    }
+  });
+
+  const summary = await service.convertFile(sourcePath);
+  const html = await fs.readFile(summary.outputPath, 'utf8');
+  assert.ok(html.includes('#00aa88'));
+});


### PR DESCRIPTION
## Summary
- add a configuration loader that discovers mdviewer.config.json next to the executable and normalises style fields
- allow the HTML template and Markdown renderer to honour injected style adjustments and expose them through the conversion service
- wire the CLI to load the configuration, copy the sample theme during packaging, and document the available style options

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cb0646469c8325857189076edf7269