### PR TITLE
Add packaging helper scripts and document build command usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,26 @@ Leave any option out to fall back to the built-in defaults.
 ### Packaging to `.exe`
 
 1. Ensure [`pkg`](https://github.com/vercel/pkg) is installed (`npm install -g pkg`) or available via `npx`.
-2. Build the TypeScript sources:
-   ```bash
-   npm run build
+2. From the repository root run the helper for your platform **or** execute the npm command manually:
+
+   ```powershell
+   # Windows PowerShell
+   .\scripts\build-exe.ps1
    ```
-3. Package the executable:
+
    ```bash
+   # Linux / macOS
+   ./scripts/build-exe.sh
+   ```
+
+   ```bash
+   # Manual invocation (from backend directory)
+   cd backend
    npm run build:exe
    ```
-   The script copies `mdviewer.config.json` into the `dist/` folder so the executable and config sit side-by-side.
+
+   Both helpers change into `backend/`, run `npm run build:exe`, and bubble up any failures so typos such as `npm rin` are surfaced early.
+3. The script copies `mdviewer.config.json` into the `dist/` folder so the executable and config sit side-by-side.
 4. The resulting binary (`dist/MdViewer.exe`) accepts Markdown files as CLI arguments or drag-and-drop payloads.
 
 ## Running Tests

--- a/docs/commits/x20240527_1530.txt
+++ b/docs/commits/x20240527_1530.txt
@@ -1,0 +1,27 @@
+Stamp: x20240527_1530
+Node: N113
+Message: Capture planning notes for build command correction
+This file: docs/commits/x20240527_1530.txt
+
+Changed Files:
+docs/notes/x20240527_1530_build_command_fix.txt
+docs/perspe/N113.md
+
+Per-file Notes:
++----------------------------------------------------------+------------------------------------------------------------------------------------+
+| File                                                     | Notes                                                                               |
++----------------------------------------------------------+------------------------------------------------------------------------------------+
+| docs/notes/x20240527_1530_build_command_fix.txt          | Logged current/future steps with ASCII planning visuals for the command correction. |
+| docs/perspe/N113.md                                      | Recorded stakeholder perspectives emphasizing script and doc clarity.              |
++----------------------------------------------------------+------------------------------------------------------------------------------------+
+
+Assumptions:
+- Documenting plans before code helps align subsequent commits with stakeholder expectations.
+
+Problems Since Last Commit:
+- None.
+
+Legend:
+- '+' shapes the borders and intersections.
+- '|' divides columns.
+- '-' spans horizontal separators.

--- a/docs/commits/x20240527_1600.txt
+++ b/docs/commits/x20240527_1600.txt
@@ -1,0 +1,27 @@
+Stamp: x20240527_1600
+Node: N113
+Message: Add PowerShell helper for packaging command
+This file: docs/commits/x20240527_1600.txt
+
+Changed Files:
+scripts/build-exe.ps1
+docs/perspe/N113.md
+
+Per-file Notes:
++--------------------------------------+-----------------------------------------------------------------------------------------+
+| File                                 | Notes                                                                                   |
++--------------------------------------+-----------------------------------------------------------------------------------------+
+| scripts/build-exe.ps1                | Added strict-mode PowerShell wrapper that executes `npm run build:exe` from backend.    |
+| docs/perspe/N113.md                  | Logged automation progress and risk watch reflections for commit 2.                     |
++--------------------------------------+-----------------------------------------------------------------------------------------+
+
+Assumptions:
+- Windows contributors prefer a ready-to-run script over memorizing npm syntax.
+
+Problems Since Last Commit:
+- None.
+
+Legend:
+- '+' forms table frames and intersections.
+- '|' separates columns.
+- '-' runs horizontal separators.

--- a/docs/commits/x20240527_1630.txt
+++ b/docs/commits/x20240527_1630.txt
@@ -1,0 +1,27 @@
+Stamp: x20240527_1630
+Node: N113
+Message: Provide Bash helper for packaging command
+This file: docs/commits/x20240527_1630.txt
+
+Changed Files:
+scripts/build-exe.sh
+docs/perspe/N113.md
+
+Per-file Notes:
++--------------------------------------+--------------------------------------------------------------------------------------------+
+| File                                 | Notes                                                                                      |
++--------------------------------------+--------------------------------------------------------------------------------------------+
+| scripts/build-exe.sh                 | Delivered executable Bash script delegating to `npm run build:exe` for Unix environments.  |
+| docs/perspe/N113.md                  | Captured cross-platform and reliability takeaways for the new helper.                      |
++--------------------------------------+--------------------------------------------------------------------------------------------+
+
+Assumptions:
+- Non-Windows contributors will appreciate parity with the PowerShell workflow.
+
+Problems Since Last Commit:
+- None.
+
+Legend:
+- '+' outlines the table and intersections.
+- '|' separates columns.
+- '-' forms horizontal lines between header and rows.

--- a/docs/commits/x20240527_1700.txt
+++ b/docs/commits/x20240527_1700.txt
@@ -1,0 +1,29 @@
+Stamp: x20240527_1700
+Node: N113
+Message: Document helper usage for packaging workflow
+This file: docs/commits/x20240527_1700.txt
+
+Changed Files:
+README.md
+docs/perspe/N113.md
+docs/notes/x20240527_1530_build_command_fix.txt
+
+Per-file Notes:
++------------------------------------------------------+----------------------------------------------------------------------------------------------+
+| File                                                 | Notes                                                                                        |
++------------------------------------------------------+----------------------------------------------------------------------------------------------+
+| README.md                                            | Added helper script walkthroughs and highlighted the correct `npm run build:exe` syntax.      |
+| docs/perspe/N113.md                                  | Summarized documentation progress and support rationale for commit 4.                        |
+| docs/notes/x20240527_1530_build_command_fix.txt      | Logged execution matrix capturing milestone completion with ASCII legend.                    |
++------------------------------------------------------+----------------------------------------------------------------------------------------------+
+
+Assumptions:
+- Making helper availability visible in README will prevent future command typos.
+
+Problems Since Last Commit:
+- None.
+
+Legend:
+- '+' frames and intersects the per-file table.
+- '|' splits columns for readability.
+- '-' spans horizontal separators.

--- a/docs/notes/x20240527_1530_build_command_fix.txt
+++ b/docs/notes/x20240527_1530_build_command_fix.txt
@@ -1,0 +1,46 @@
+# Build Command Correction Planning
+
++------------------+--------------------------------------------------------------+--------------------------------------------------------------+--------------------------------------------------------------+-----------------------------------------------------------------------+
+| Track            | Current Steps                                                | Future Steps                                                 | Self-Considerations                                           | Role Perspectives                                                     |
++------------------+--------------------------------------------------------------+--------------------------------------------------------------+--------------------------------------------------------------+-----------------------------------------------------------------------+
+| Documentation    | Identify README gaps about the executable build command.     | Draft explicit instructions emphasizing `npm run build:exe`. | Ensure tone stays concise while guiding Windows users.       | QA wants reproducible commands; Dev Principal expects clarity.       |
+| Automation       | Audit missing helper scripts for Windows packaging.          | Provide PowerShell launcher with safe error handling.        | Keep dependencies minimal to avoid setup friction.           | DevOps anticipates pipeline reuse; Dreamer imagines GUI wrapper.     |
+| Cross-Platform   | Evaluate whether Linux/Mac contributors need parity tooling. | Add Bash helper script mirroring the PowerShell workflow.    | Confirm scripts respect repo relative paths for portability. | Typical Client values copy-paste simplicity across environments.     |
+| Communication    | Prepare perspectives and commit documentation requirements.  | Publish structured notes and perspective reflections.        | Double-check ASCII formatting before committing.             | Junior Dev learns workflow discipline; High Feature Creator plots UX.|
++------------------+--------------------------------------------------------------+--------------------------------------------------------------+--------------------------------------------------------------+-----------------------------------------------------------------------+
+
+Legend:
+- '+' marks intersections and frame corners.
+- '|' separates columns vertically.
+- '-' extends horizontal separators across the table width.
+
+ASCII Flow Snapshot:
+
+      [Plan]=====>{Docs Update}=====>{Automation Scripts}
+           \\
+            \\
+             ==> {Communicate Perspectives}
+
+Legend:
+- '[' and ']' enclose milestones.
+- '{' and '}' denote deliverables or artifacts.
+- '=' shows sequential flow.
+- '\\' sketches supporting substreams connecting outcomes.
+- '>' indicates progression direction.
+
+## Execution Matrix
+
++-------------------------+------------------------+------------------------+-----------------------------------------------+
+| Milestone               | Owner Signal           | Status                 | Notes                                         |
++-------------------------+------------------------+------------------------+-----------------------------------------------+
+| PowerShell Helper       | Automation Thread      | Completed ✅           | Script auto-navigates into backend directory. |
+| Bash Helper             | Cross-Platform Thread  | Completed ✅           | Mirrors PowerShell behaviour on Unix shells. |
+| README Refresh          | Documentation Thread   | Completed ✅           | Clarifies `npm run build:exe` usage paths.    |
+| Perspective Tracking    | Communication Thread   | Completed ✅           | Tables logged after every commit iteration.   |
++-------------------------+------------------------+------------------------+-----------------------------------------------+
+
+Legend:
+- '+' builds matrix borders and intersection points.
+- '|' splits columns for readability.
+- '-' stretches horizontal dividers.
+- '✅' indicates successful completion of a milestone.

--- a/docs/perspe/N113.md
+++ b/docs/perspe/N113.md
@@ -1,0 +1,64 @@
+# Node N113 Perspectives
+
++-------------------------------+--------------------------------------------------------------------------------------------+
+| Perspective                   | Thoughts                                                                                    |
++-------------------------------+--------------------------------------------------------------------------------------------+
+| QA                            | Wants explicit reproduction steps pointing to `npm run build:exe` and helper scripts.       |
+| Dev                           | Plans modular scripts so packaging logic remains maintainable and reviewable.               |
+| Junior Dev                    | Looks forward to learning how scripts bridge documentation and automation workflows.       |
+| Dreamer Dev                   | Envisions a cross-platform launcher menu that wraps npm commands for novices.              |
+| Typical Client                | Needs a straightforward way to generate the Windows executable without reading npm docs.   |
+| Dev Principal                 | Emphasizes keeping commit documentation synchronized with new helper tooling.              |
+| DevOps                        | Prioritizes scripts with deterministic paths suitable for CI/CD packaging tasks.           |
+| High Dreaming Feature Creator | Imagines future GUI toggles exposing build presets (debug, theming, architecture).         |
++-------------------------------+--------------------------------------------------------------------------------------------+
+
+Legend:
+- '+' frames the table and intersections.
+- '|' divides perspective names from their reflections.
+- '-' spans horizontal separators.
+
+## Progress Update - Commit 2
+
++----------------------+---------------------------------------------------------------+
+| Focus Area           | Update                                                        |
++----------------------+---------------------------------------------------------------+
+| Automation           | PowerShell helper crafted to call `npm run build:exe` safely. |
+| Communication        | Script messaging highlights backend path and exit reporting.  |
+| Risk Watch           | Ensured strict mode prevents silent failures.                 |
++----------------------+---------------------------------------------------------------+
+
+Legend:
+- '+' forms the frame and intersections for the update table.
+- '|' separates the descriptor column from the narrative column.
+- '-' stretches horizontal rules across the table width.
+
+## Progress Update - Commit 3
+
++----------------------+-------------------------------------------------------------------+
+| Focus Area           | Update                                                            |
++----------------------+-------------------------------------------------------------------+
+| Cross-Platform       | Added Bash helper so Linux/macOS users mirror the Windows flow.   |
+| Reliability          | Enabled `set -euo pipefail` to abort on missing dependencies.     |
+| Experience           | Emit consistent messaging about backend execution context.        |
++----------------------+-------------------------------------------------------------------+
+
+Legend:
+- '+' frames and intersects the table layout.
+- '|' divides focus areas from updates.
+- '-' draws the horizontal separators between rows.
+
+## Progress Update - Commit 4
+
++----------------------+--------------------------------------------------------------------------+
+| Focus Area           | Update                                                                   |
++----------------------+--------------------------------------------------------------------------+
+| Documentation        | README now highlights helper scripts and the exact `npm run` syntax.     |
+| Support              | Clarified how tooling prevents typos like `npm rin` during packaging.    |
+| Outreach             | Pointed contributors to platform-specific helpers from repository root.  |
++----------------------+--------------------------------------------------------------------------+
+
+Legend:
+- '+' constructs the table boundaries and joints.
+- '|' splits focus areas from their narrative updates.
+- '-' carries the horizontal separators.

--- a/scripts/build-exe.ps1
+++ b/scripts/build-exe.ps1
@@ -1,0 +1,29 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$backendPath = Join-Path $repoRoot 'backend'
+
+if (-not (Test-Path -LiteralPath $backendPath)) {
+    throw "Backend directory not found at '$backendPath'."
+}
+
+$npm = Get-Command npm -ErrorAction Stop
+$npmArgs = @('run', 'build:exe')
+
+Write-Host "Running: npm $($npmArgs -join ' ') in $backendPath" -ForegroundColor Cyan
+
+Push-Location -Path $backendPath
+try {
+    & $npm.Source @npmArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "npm run build:exe failed with exit code $LASTEXITCODE."
+    }
+    Write-Host "Executable build completed. Output in backend/dist." -ForegroundColor Green
+}
+finally {
+    Pop-Location
+}

--- a/scripts/build-exe.sh
+++ b/scripts/build-exe.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+backend_dir="$repo_root/backend"
+
+if [[ ! -d "$backend_dir" ]]; then
+  echo "Backend directory not found at '$backend_dir'." >&2
+  exit 1
+fi
+
+echo "Running: npm run build:exe inside $backend_dir"
+(
+  cd "$backend_dir"
+  npm run build:exe
+)


### PR DESCRIPTION
## Summary
- add PowerShell and Bash helper scripts that execute `npm run build:exe` from the repository root and bubble up failures
- refresh packaging instructions so Windows and Unix users know how to avoid typos like `npm rin`
- capture planning and perspective documentation for node N113 while tracking milestone completion

## Testing
- `npm install` *(fails: 403 Forbidden when fetching typescript from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cb137f604c83259d0ae2e6159f056f